### PR TITLE
NIT-670 update pipeline to use new short-lived credentials

### DIFF
--- a/.github/workflows/cloud-platform-sandbox-build-deploy.yml
+++ b/.github/workflows/cloud-platform-sandbox-build-deploy.yml
@@ -26,7 +26,6 @@ on:
   #     - '.github/workflows/cloud-platform-sandbox-build-deploy.yml'
 
 env:
-  IMAGE_REPOSITORY_NAME: hmpps-cr-ancillary-jitbit-app-cloud-platform/hmpps-community-rehabilitation-ancilliary-jitbit-dev-ecr
   KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
   JITBIT_APP_VERSION: ${{ inputs.jitbit_app_version }}
   # For testing purposes only:
@@ -35,34 +34,14 @@ env:
 jobs:
   build_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
     steps:
-      - name: Configure aws credentials for ECR image test
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
-        with:
-          aws-access-key-id: ${{ secrets.CP_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CP_ECR_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Docker login
-        run: aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${{ secrets.CP_AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com
-
-      - name: Test image version
-        id: test-image-version
-        run: |
-            imageExist=true
-            imageDigest=$(aws ecr list-images --repository-name $IMAGE_REPOSITORY_NAME | jq -r '.imageIds[] | select(.imageTag=="${{ env.JITBIT_APP_VERSION }}") | .imageDigest')
-            if [[ -z "$imageDigest" ]]; then 
-              imageExist=false
-            fi
-            echo "Image digest: $imageDigest"
-            echo "imageExist=$imageExist" >> $GITHUB_OUTPUT
-
       - name: Checkout Jitbit app repo
-        if: steps.test-image-version.outputs.imageExist == 'false'
         uses: actions/checkout@v3
 
       - name: Configure aws credentials for S3 download
-        if: steps.test-image-version.outputs.imageExist == 'false'
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-access-key-id: ${{ secrets.CP_S3_ARTEFACTS_ACCESS_KEY_ID }}
@@ -70,19 +49,30 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Pull down S3 app files
-        if: steps.test-image-version.outputs.imageExist == 'false'
         run: aws s3 cp s3://${{ secrets.CP_S3_ARTEFACTS_BUCKET }}/app/HelpDesk_$JITBIT_APP_VERSION docker/app/HelpDesk_$JITBIT_APP_VERSION  --recursive
 
+      - name: Configure aws credentials for ECR image test
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v1
+        id: login-ecr
+
       - name: Docker build and tag
-        if: steps.test-image-version.outputs.imageExist == 'false'
-        run: docker build --no-cache -t "${{ secrets.CP_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/$IMAGE_REPOSITORY_NAME:$JITBIT_APP_VERSION" --build-arg JITBIT_APP_VERSION=$JITBIT_APP_VERSION ./docker
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+        run: docker build --no-cache -t $REGISTRY/$REPOSITORY:$JITBIT_APP_VERSION --build-arg JITBIT_APP_VERSION=$JITBIT_APP_VERSION ./docker
 
       - name: Docker push
-        if: steps.test-image-version.outputs.imageExist == 'false'
-        run: docker push ${{ secrets.CP_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/$IMAGE_REPOSITORY_NAME:$JITBIT_APP_VERSION
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+        run: docker push $REGISTRY/$REPOSITORY:$JITBIT_APP_VERSION
 
       - name: Authenticate to k8s
-        if: steps.test-image-version.outputs.imageExist == 'false'
         run: |
             echo "${{ secrets.KUBE_CERT }}" > ca.crt
             kubectl config set-cluster ${{ secrets.KUBE_CLUSTER }} --certificate-authority=./ca.crt --server=https://${{ secrets.KUBE_CLUSTER }}
@@ -92,9 +82,7 @@ jobs:
 
       - name: Deploy to Cloud platform sandbox environment
         run: |
-            helm upgrade jitbit helm/jitbit --install -n $KUBE_NAMESPACE \
+            helm upgrade jitbit ./helm/jitbit --install -n $KUBE_NAMESPACE \
               --set database.dbConnectionString="${{ secrets.CP_RDS_JITBIT_DATABASE_CONNECTION_STRING }}" \
               --set image.tag=$JITBIT_APP_VERSION
               # For testing purposees: --dry-run
-
-        


### PR DESCRIPTION
Cloud Platform docs for context: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-github-actions

Test if image exists was removed, as the new role does not have an identity-based policy that allows the ecr:ListImages action.