### PR TITLE
Remove aquasecurity/trivy-action from .github/workflows/jitbit-build-push-image-reusable.yml

### DIFF
--- a/.github/workflows/jitbit-build-push-image-reusable.yml
+++ b/.github/workflows/jitbit-build-push-image-reusable.yml
@@ -87,18 +87,9 @@ jobs:
 
       - name: Trivy scan
         id: trivy
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0
-        with:
-          format: "sarif"
-          limit-severities-for-sarif: "true"
-          severity: "MEDIUM,HIGH,CRITICAL"
-          image-ref: "delius-jitbit-ecr-repo:${{ inputs.jitbit_version }}-${{ github.run_id }}"
-          exit-code: "1"
-          scan-type: "image"
-          trivyignores: ".trivyignore"
-          ignore-unfixed: "true"
-          output: "trivy-results.sarif"
-
+        run: |
+          echo '{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}' > 'trivy-results.sarif'
+          echo 'trivy-action step removed — created empty SARIF stub'
       - name: Slack notification if vulnerabilities found
         if: failure()
         run: |


### PR DESCRIPTION
## Why

`aquasecurity/trivy-action` has been compromised for the second time. All tags before `0.35.0` were re-pointed to a malicious commit that **dumps process memory to steal credentials** from CI runners.

- **Issue:** https://github.com/aquasecurity/trivy-action/issues/541
- **Exposure window (UTC):** 2026-03-19 ~17:43 – 2026-03-20 ~05:40
- **Malicious commit:** `aquasecurity/setup-trivy@8afa9b9`
- **Details:** https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release

As [recommended by the maintainers](https://github.com/aquasecurity/trivy-action/issues/541#issuecomment-2737987938):

> "As hard as it may be: do not use Trivy anymore for now."

Any repository that ran a workflow using this action during the exposure window may have had secrets exfiltrated. **Rotate any secrets that were available to workflows using this action.**

## What this PR does

Removes the `aquasecurity/trivy-action` step(s) from this workflow. The `uses:` directive and its `with:` block have been replaced with a `run:` step that creates an empty but valid SARIF file (where applicable), so downstream steps (e.g. `upload-sarif`) continue to pass.

> **Note:** Repo owners should review whether the entire workflow/job can now be removed, or whether an alternative scanning solution should be adopted.

Raised automatically for review.
